### PR TITLE
updated docker expose to fix unix path issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   attendance-node1:
     build:
-      context: NodeJS\.
+      context: NodeJS/.
       dockerfile: Dockerfile
     container_name: attendance-node1
     expose:
@@ -17,7 +17,7 @@ services:
   nginx:
     container_name: nginx
     build:
-      context: .\Http
+      context: Http/.
       dockerfile: Dockerfile
     ports:
       - target: 80


### PR DESCRIPTION
The paths had a `\` and that doesn't work on unix so this change should fix that